### PR TITLE
Commented out copyField for creator field in schema.xml (Solr).

### DIFF
--- a/conf/solr/8.8.1/schema.xml
+++ b/conf/solr/8.8.1/schema.xml
@@ -331,7 +331,7 @@
     <copyField source="coverage.Temporal" dest="_text_" maxChars="3000"/>
     <copyField source="coverage.Temporal.StartTime" dest="_text_" maxChars="3000"/>
     <copyField source="coverage.Temporal.StopTime" dest="_text_" maxChars="3000"/>
-    <copyField source="creator" dest="_text_" maxChars="3000"/>
+<!--    <copyField source="creator" dest="_text_" maxChars="3000"/>-->
     <copyField source="dataCollectionSituation" dest="_text_" maxChars="3000"/>
     <copyField source="dataCollector" dest="_text_" maxChars="3000"/>
     <copyField source="dataSources" dest="_text_" maxChars="3000"/>


### PR DESCRIPTION
This line caused updateSchemaMDB.sh to fail because the creator field aparently has to be added first. It was added for a PoC in 1792fc29ea7ed0879fb660c5d94e445c4669b20e.

