### PR TITLE
Worked around NPE

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -715,7 +715,9 @@ public class JsonPrinter {
                 if (!cvocEntry.containsKey("retrieval-filtering")) {
                     valueArrStack.peek().add(dsfv.getValue());
                 } else {
-                    valueArrStack.peek().add(datasetFieldService.getExternalVocabularyValue(dsfv.getValue()));
+                    JsonObject value = datasetFieldService.getExternalVocabularyValue(dsfv.getValue());
+                    if (value != null)
+                        valueArrStack.peek().add(value);
                 }
             }
         }


### PR DESCRIPTION
@qqmyers : not sure that this is the correct fix. The problem is a NPE (and then 500 Internal Server Error) when showing any dataset that cannot retrieve the external vocabulary value.