### PR TITLE
add dev guide links to list of APIs #6497

### DIFF
--- a/doc/sphinx-guides/source/api/intro.rst
+++ b/doc/sphinx-guides/source/api/intro.rst
@@ -204,6 +204,15 @@ Please note that some APIs are only documented in other guides that are more sui
 
   - :doc:`/installation/config`
 
+- Developer Guide
+
+  - :doc:`/developers/aux-file-support`
+  - :doc:`/developers/big-data-support`
+  - :doc:`/developers/dataset-migration-api`
+  - :doc:`/developers/dataset-semantic-metadata-api`
+  - :doc:`/developers/s3-direct-upload-api`
+  - :doc:`/developers/workflows`
+
 Client Libraries
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
As @qqmyers and I discussed in https://github.com/IQSS/dataverse/pull/7504 we want the list of APIs to be comprehensive, including APIs that are only in the dev guide.