### PR TITLE
Retrieve vocabs fields as JSON object rather than JSON array.

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldServiceBean.java
@@ -641,11 +641,12 @@ public class DatasetFieldServiceBean implements java.io.Serializable {
      */
     public boolean isValidCVocValue(DatasetFieldType dft, String value) {
         JsonObject jo = getCVocConf(true).get(dft.getId());
-        JsonArray vocabs = jo.getJsonArray("vocabs");
+        JsonObject vocabs = jo.getJsonObject("vocabs");
         boolean valid = false;
         boolean couldBeFreeText = true;
         boolean freeTextAllowed = jo.getBoolean("allow-free-text", false);
-        for (JsonObject vocab : vocabs.getValuesAs(JsonObject.class)) {
+        for (String vocabName : vocabs.keySet()) {
+            JsonObject vocab = vocabs.getJsonObject(vocabName);
             String baseUri = vocab.getString("uriSpace");
             if (value.startsWith(baseUri)) {
                 valid = true;


### PR DESCRIPTION
When adding a value to an external CVOC field through the API, an exception is thrown from `edu.harvard.iq.dataverse.DatasetFieldServiceBean#isValidCVocValue`:

```
javax.ejb.TransactionRolledbackLocalException: Exception thrown from bean: java.lang.ClassCastException: class org.glassfish.json.JsonObjectBuilderImpl$JsonObjectImpl cannot be cast to class javax.json.JsonArray (org.glassfish.jso
n.JsonObjectBuilderImpl$JsonObjectImpl and javax.json.JsonArray are in unnamed module of loader org.apache.felix.framework.BundleWiringImpl$BundleClassLoader @6c24e501)
        at com.sun.ejb.containers.EJBContainerTransactionManager.checkExceptionClientTx(EJBContainerTransactionManager.java:615)
        at com.sun.ejb.containers.EJBContainerTransactionManager.postInvokeTx(EJBContainerTransactionManager.java:485)
        at com.sun.ejb.containers.BaseContainer.postInvokeTx(BaseContainer.java:4592)
        at com.sun.ejb.containers.BaseContainer.postInvoke(BaseContainer.java:2125)
        at com.sun.ejb.containers.BaseContainer.postInvoke(BaseContainer.java:2095)
        at com.sun.ejb.containers.EJBLocalObjectInvocationHandler.invoke(EJBLocalObjectInvocationHandler.java:220)
        at com.sun.ejb.containers.EJBLocalObjectInvocationHandlerDelegate.invoke(EJBLocalObjectInvocationHandlerDelegate.java:90)
        at com.sun.proxy.$Proxy304.isValidCVocValue(Unknown Source)
        at edu.harvard.iq.dataverse.__EJB31_Generated__DatasetFieldServiceBean__Intf____Bean__.isValidCVocValue(Unknown Source)
        at edu.harvard.iq.dataverse.util.json.JsonParser.parsePrimitiveValue(JsonParser.java:720)
        at edu.harvard.iq.dataverse.util.json.JsonParser.parseField(JsonParser.java:615)
        at edu.harvard.iq.dataverse.util.json.JsonParser.parseFieldsFromArray(JsonParser.java:404)
        at edu.harvard.iq.dataverse.util.json.JsonParser.parseMetadataBlocks(JsonParser.java:381)
        at edu.harvard.iq.dataverse.util.json.JsonParser.parseDatasetVersion(JsonParser.java:345)
        at edu.harvard.iq.dataverse.util.json.JsonParser.parseDataset(JsonParser.java:285)
        at edu.harvard.iq.dataverse.api.Dataverses.parseDataset(Dataverses.java:512)
        at edu.harvard.iq.dataverse.api.Dataverses.importDataset(Dataverses.java:325)
```
The reason is that the retrieved "vocabs" field is not an array, but an object.