### PR TITLE
#8390 Counter Processor v0.1.04 requires Python 3.7 or higher.

### DIFF
--- a/doc/sphinx-guides/source/admin/make-data-count.rst
+++ b/doc/sphinx-guides/source/admin/make-data-count.rst
@@ -112,7 +112,7 @@ Soon we will be setting up a cron job to run nightly but we start with a single 
  
 * Run Counter Processor.
 
-  * ``CONFIG_FILE=counter-processor-config.yaml python36 main.py``
+  * ``CONFIG_FILE=counter-processor-config.yaml python39 main.py``
 
   * A JSON file in SUSHI format will be created in the directory you specified under "output_file" in the config file.
 

--- a/doc/sphinx-guides/source/developers/make-data-count.rst
+++ b/doc/sphinx-guides/source/developers/make-data-count.rst
@@ -53,7 +53,7 @@ Once you are done with your configuration, you can run Counter Processor like th
 
 ``cd /usr/local/counter-processor-0.1.04``
 
-``CONFIG_FILE=counter-processor-config.yaml python36 main.py``
+``CONFIG_FILE=counter-processor-config.yaml python39 main.py``
 
 (Please note that the Counter Processor README says you can also pass in values like ``START_DATE``, ``END_DATE`` etc. at the command line if you find this to be more convenient.)
 

--- a/doc/sphinx-guides/source/installation/prerequisites.rst
+++ b/doc/sphinx-guides/source/installation/prerequisites.rst
@@ -416,7 +416,7 @@ Counter Processor is required to enable Make Data Count metrics in a Dataverse i
 Installing Counter Processor
 ============================
 
-Counter Processor has only been tested on el7 (see "Linux" above). Please note that a scripted installation using Ansible is mentioned in the :doc:`/developers/make-data-count` section of the Developer Guide.
+A scripted installation using Ansible is mentioned in the :doc:`/developers/make-data-count` section of the Developer Guide.
 
 As root, download and install Counter Processor::
 
@@ -449,19 +449,17 @@ As root, create a "counter" user and change ownership of Counter Processor direc
 Installing Counter Processor Python Requirements
 ================================================
 
-Counter Processor requires Python 3.7 or higher. The following commands are intended to be run as root but we are aware that Pythonistas might prefer fancy virtualenv or similar setups. Pull requests are welcome to improve these steps!
+Counter Processor version 0.1.04 requires Python 3.7 or higher. This version of Python is available in many operating systems, and is purportedly available for RHEL7 or CentOS 7 via Red Hat Software Collections. Alternately, one may compile it from source.
 
-Enable the EPEL repo if you haven't already::
+The following commands are intended to be run as root but we are aware that Pythonistas might prefer fancy virtualenv or similar setups. Pull requests are welcome to improve these steps!
 
-        yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+Install Python 3.9::
 
-Install Python 3.6::
-
-        yum install python36
+        yum install python39
 
 Install Counter Processor Python requirements::
 
-        python3.6 -m ensurepip
+        python3.9 -m ensurepip
         cd /usr/local/counter-processor-0.1.04
         pip3 install -r requirements.txt
 


### PR DESCRIPTION
bump documentation from Python 3.6 to 3.7+