### PR TITLE
Amendment

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetFieldType.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetFieldType.java
@@ -284,7 +284,7 @@ public class DatasetFieldType implements Serializable, Comparable<DatasetFieldTy
     }
     
     public boolean isControlledVocabulary() {
-        return controlledVocabularyValues != null && !controlledVocabularyValues.isEmpty();
+        return allowControlledVocabulary;
     }
 
     /**


### PR DESCRIPTION
As discussed with @qqmyers changing `DatasetFieldType.isControlledVocabulary()` to return `allowControlledVocabulary` instead of accessing the database to see if the list of terms is non-empty. This gets rid of NPE's in EclipseLink's AbstractSession.executeDeferredEvents, e.g.,

```
  java.lang.NullPointerException
        at org.eclipse.persistence.internal.sessions.AbstractSession.executeDeferredEvents(AbstractSession.java:1534)
        at org.eclipse.persistence.internal.sessions.UnitOfWorkImpl.internalExecuteQuery(UnitOfWorkImpl.java:3005)
        at org.eclipse.persistence.internal.sessions.AbstractSession.executeQuery(AbstractSession.java:1898)
        at org.eclipse.persistence.internal.sessions.AbstractSession.executeQuery(AbstractSession.java:1880)
```

which are presumably caused by using the EntityManager from a thread that is not supposed to use it. See also: https://stackoverflow.com/questions/73974404/npe-in-eclipse-link-abstractsession-executedeferredeventsabstractsession-java1