### PR TITLE
Amend metadata block TSVs

### DIFF
--- a/doc/release-notes/9983-unique-constraints.md
+++ b/doc/release-notes/9983-unique-constraints.md
@@ -7,3 +7,8 @@ and
 SELECT spec, count(*) FROM oaiset group by spec;
 
 and then removing any duplicate rows (where count>1).
+
+
+
+
+TODO: Add note about reloading metadata blocks after upgrade.

--- a/scripts/api/data/metadatablocks/astrophysics.tsv
+++ b/scripts/api/data/metadatablocks/astrophysics.tsv
@@ -2,13 +2,13 @@
 	astrophysics		Astronomy and Astrophysics Metadata													
 #datasetField	name	title	description	watermark	 fieldType	displayOrder	displayFormat	advancedSearchField	allowControlledVocabulary	allowmultiples	facetable	displayoncreate	required	parent	metadatablock_id
 	astroType	Type	The nature or genre of the content of the files in the dataset.		text	0		TRUE	TRUE	TRUE	TRUE	FALSE	FALSE		astrophysics
-	astroFacility	Facility	The observatory or facility where the data was obtained. 		text	1		TRUE	TRUE	TRUE	TRUE	FALSE	FALSE		astrophysics
-	astroInstrument	Instrument	The instrument used to collect the data.		text	2		TRUE	TRUE	TRUE	TRUE	FALSE	FALSE		astrophysics
+	astroFacility	Facility	The observatory or facility where the data was obtained. 		text	1		TRUE	FALSE	TRUE	TRUE	FALSE	FALSE		astrophysics
+	astroInstrument	Instrument	The instrument used to collect the data.		text	2		TRUE	FALSE	TRUE	TRUE	FALSE	FALSE		astrophysics
 	astroObject	Object	Astronomical Objects represented in the data (Given as SIMBAD recognizable names preferred).		text	3		TRUE	FALSE	TRUE	TRUE	FALSE	FALSE		astrophysics
 	resolution.Spatial	Spatial Resolution	The spatial (angular) resolution that is typical of the observations, in decimal degrees.		text	4		TRUE	FALSE	FALSE	TRUE	FALSE	FALSE		astrophysics
 	resolution.Spectral	Spectral Resolution	The spectral resolution that is typical of the observations, given as the ratio \u03bb/\u0394\u03bb.		text	5		TRUE	FALSE	FALSE	TRUE	FALSE	FALSE		astrophysics
 	resolution.Temporal	Time Resolution	The temporal resolution that is typical of the observations, given in seconds.		text	6		FALSE	FALSE	FALSE	FALSE	FALSE	FALSE		astrophysics
-	coverage.Spectral.Bandpass	Bandpass	Conventional bandpass name		text	7		TRUE	TRUE	TRUE	TRUE	FALSE	FALSE		astrophysics
+	coverage.Spectral.Bandpass	Bandpass	Conventional bandpass name		text	7		TRUE	FALSE	TRUE	TRUE	FALSE	FALSE		astrophysics
 	coverage.Spectral.CentralWavelength	Central Wavelength (m)	The central wavelength of the spectral bandpass, in meters.	Enter a floating-point number.	float	8		TRUE	FALSE	TRUE	TRUE	FALSE	FALSE		astrophysics
 	coverage.Spectral.Wavelength	Wavelength Range	The minimum and maximum wavelength of the spectral bandpass.	Enter a floating-point number.	none	9		FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		astrophysics
 	coverage.Spectral.MinimumWavelength	Minimum (m)	The minimum wavelength of the spectral bandpass, in meters.	Enter a floating-point number.	float	10		TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	coverage.Spectral.Wavelength	astrophysics

--- a/scripts/api/data/metadatablocks/biomedical.tsv
+++ b/scripts/api/data/metadatablocks/biomedical.tsv
@@ -13,7 +13,7 @@
 	studyAssayOtherTechnologyType	Other Technology Type	If Other was selected in Technology Type, list any other technology types that were used in this Dataset.		text	9		TRUE	FALSE	TRUE	TRUE	FALSE	FALSE		biomedical
 	studyAssayPlatform	Technology Platform	The manufacturer and name of the technology platform used in the assay (e.g. Bruker AVANCE).		text	10		TRUE	TRUE	TRUE	TRUE	FALSE	FALSE		biomedical
 	studyAssayOtherPlatform	Other Technology Platform	If Other was selected in Technology Platform, list any other technology platforms that were used in this Dataset.		text	11		TRUE	FALSE	TRUE	TRUE	FALSE	FALSE		biomedical
-	studyAssayCellType	Cell Type	The name of the cell line from which the source or sample derives.		text	12		TRUE	TRUE	TRUE	TRUE	FALSE	FALSE		biomedical
+	studyAssayCellType	Cell Type	The name of the cell line from which the source or sample derives.		text	12		TRUE	FALSE	TRUE	TRUE	FALSE	FALSE		biomedical
 #controlledVocabulary	DatasetField	Value	identifier	displayOrder											
 	studyDesignType	Case Control	EFO_0001427	0											
 	studyDesignType	Cross Sectional	EFO_0001428	1											

--- a/scripts/api/data/metadatablocks/citation.tsv
+++ b/scripts/api/data/metadatablocks/citation.tsv
@@ -70,7 +70,7 @@
 	seriesName	Name	The name of the dataset series		text	66	#VALUE	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	series	citation	
 	seriesInformation	Information	Can include 1) a history of the series and 2) a summary of features that apply to the series		textbox	67	#VALUE	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	series	citation	
 	software	Software	Information about the software used to generate the Dataset		none	68	,	FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	https://www.w3.org/TR/prov-o/#wasGeneratedBy
-	softwareName	Name	The name of software used to generate the Dataset		text	69	#VALUE	FALSE	TRUE	FALSE	FALSE	FALSE	FALSE	software	citation	
+	softwareName	Name	The name of software used to generate the Dataset		text	69	#VALUE	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	software	citation
 	softwareVersion	Version	The version of the software used to generate the Dataset, e.g. 4.11		text	70	#NAME: #VALUE	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	software	citation	
 	relatedMaterial	Related Material	Information, such as a persistent ID or citation, about the material related to the Dataset, such as appendices or sampling information available outside of the Dataset		textbox	71		FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	
 	relatedDatasets	Related Dataset	Information, such as a persistent ID or citation, about a related dataset, such as previous research on the Dataset's subject		textbox	72		FALSE	FALSE	TRUE	FALSE	FALSE	FALSE		citation	http://purl.org/dc/terms/relation


### PR DESCRIPTION
Change the metadata block field definitions where the field had `allowControlledVocabulary` set to `TRUE` but no vocabulary was provided. This would result in the field effectively being treated as `allowControlledVocabulary` set to `FALSE` before the change to [isControlledVocabulary()](https://github.com/IQSS/dataverse/pull/9984/files#diff-2ac8f28783502f9c3b2851dad2a98bcdde43a58151a100d682d2d80791e7c82aL287). These fields are now explicitly `allowControlledVocabulary` = `FALSE`.